### PR TITLE
Fix advanced worksheet submission name handling

### DIFF
--- a/advanced.js
+++ b/advanced.js
@@ -4,8 +4,15 @@ async function submitAdv(e, week) {
   e.preventDefault();
   const form = e.target;
   const msg = form.querySelector('.msg');
-  const studentName = prompt('Please enter your name so we can record your Week ' + week + ' advanced activity:');
-  if (!studentName) return;
+  const nameInput = form.querySelector('[name="studentName"]');
+  const studentName = nameInput ? nameInput.value.trim() : '';
+  if (!studentName) {
+    if (msg) {
+      msg.textContent = 'Please enter your name.';
+      msg.style.color = 'red';
+    }
+    return;
+  }
 
   const answers = [];
   form.querySelectorAll('textarea').forEach((ta) => {


### PR DESCRIPTION
## Summary
- Read student name from the advanced worksheet form rather than prompting
- Provide user feedback if name missing before sending to Apps Script

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688d7997e3d083269503a287c975e661