### PR TITLE
Align Clock with shared Timber course shell

### DIFF
--- a/course-family-navigation.css
+++ b/course-family-navigation.css
@@ -1,0 +1,13 @@
+:root { --hub-ink: #173b59; --hub-paper: #f7fafc; }
+.course-family-nav { background: var(--hub-paper); border-top: 2px solid #102b3d; border-bottom: 1px solid #dbe4e9; color: var(--hub-ink); position: relative; width: 100%; z-index: 1000; }
+.course-family-nav *, .course-family-nav *::before, .course-family-nav *::after { box-sizing: border-box; }
+.course-family-nav__inner { align-items: center; display: flex; gap: 1.15rem 2rem; margin: 0 auto; max-width: 1440px; min-height: 82px; padding: 0.8rem 1.25rem; }
+.course-family-nav__brand { align-items: center; color: var(--hub-ink); display: inline-flex; flex: 0 0 auto; font-size: 1.05rem; font-weight: 850; gap: 0.7rem; line-height: 1.2; text-decoration: none; }
+.course-family-nav__mark { align-items: center; background: #e9b662; border-radius: 50%; color: #173b59; display: inline-flex; font-size: 0.75rem; font-weight: 900; height: 42px; justify-content: center; letter-spacing: -0.04em; width: 42px; }
+.course-family-nav__links { align-items: center; display: flex; flex: 1 1 auto; flex-wrap: wrap; gap: 0.25rem 0.4rem; }
+.course-family-nav__links a { border-radius: 12px; color: var(--hub-ink); display: inline-flex; font-size: 1rem; font-weight: 760; line-height: 1.2; padding: 0.72rem 0.78rem; text-decoration: none; white-space: nowrap; }
+.course-family-nav__links a:hover, .course-family-nav__links a:focus-visible { background: #e9f0f4; color: #102f4a; outline: 3px solid #d5e0e7; outline-offset: 2px; }
+.course-family-nav__links a[aria-current="page"] { background: #e2ecf2; color: #173b59; }
+.has-course-family-nav .hub-return-bar, .has-course-family-nav .site-header, .has-course-family-nav .course-bar { display: none !important; }
+@media (max-width: 780px) { .course-family-nav { position: relative; } .course-family-nav__inner { display: grid; gap: 0.6rem; min-height: 0; padding: 0.7rem 0.8rem 0.55rem; } .course-family-nav__brand { font-size: 1rem; } .course-family-nav__mark { height: 36px; width: 36px; } .course-family-nav__links { flex-wrap: nowrap; margin-inline: -0.8rem; overflow-x: auto; padding: 0 0.8rem 0.45rem; scrollbar-width: thin; } .course-family-nav__links a { flex: 0 0 auto; font-size: 0.92rem; padding: 0.62rem 0.72rem; } }
+@media print { .course-family-nav { display: none !important; } }

--- a/front-page-cleanup.css
+++ b/front-page-cleanup.css
@@ -3,3 +3,6 @@
 .welcome-card,
 .course-path { display:none!important; }
 .week-card .button-link { background:transparent!important; border:0!important; border-radius:inherit!important; box-shadow:none!important; }
+
+/* Let the Clock fill its hero frame while keeping the project centred. */
+.course-family-hero .hero-showcase .clock-hero-product { object-fit:cover !important; object-position:center 48% !important; padding:0 !important; }

--- a/front-page-cleanup.css
+++ b/front-page-cleanup.css
@@ -4,5 +4,17 @@
 .course-path { display:none!important; }
 .week-card .button-link { background:transparent!important; border:0!important; border-radius:inherit!important; box-shadow:none!important; }
 
-/* Let the Clock fill its hero frame while keeping the project centred. */
-.course-family-hero .hero-showcase .clock-hero-product { object-fit:cover !important; object-position:center 48% !important; padding:0 !important; }
+/* Keep one shared hero frame and centre the Clock within it. */
+.course-family-hero .hero-showcase{padding:0!important}
+.course-family-hero .hero-showcase .clock-hero-product{
+  aspect-ratio:auto!important;
+  border:0!important;
+  border-radius:0!important;
+  box-shadow:none!important;
+  height:100%!important;
+  object-fit:cover!important;
+  object-position:center 52%!important;
+  padding:0!important;
+  transform:none!important;
+  width:100%!important;
+}

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
         <p class="eyebrow">Year 9 Industrial Technology – Timber</p>
         <h1>Clock Guided Course</h1>
         <p class="hero-subtitle">Read the plan. Build in sequence. Prove every decision.</p>
-        <div class="hero-actions"><a class="button-link" href="weeks1-2/index.html">Begin Weeks 1–2</a><a class="button-link secondary" href="clock-folio.html">Open Project Folio</a><a class="button-link secondary" href="Drawing%201%20(1).pdf" target="_blank" rel="noopener">Open Plans</a></div>
+        <div class="hero-actions"><a class="button-link" href="weeks1-2/index.html">Start Module 1</a><a class="button-link secondary" href="clock-folio.html">Open Project Folio</a></div>
       </div>
       <figure class="hero-showcase hero-image-contain">
         <img class="hero-chair clock-hero-product" src="assets/clock-hero-illustrative-v3.png" alt="Timber clock similar in form to the student Clock project, shown in a school workshop setting">

--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
         <p class="hero-subtitle">Read the plan. Build in sequence. Prove every decision.</p>
         <div class="hero-actions"><a class="button-link" href="weeks1-2/index.html">Start Module 1</a><a class="button-link secondary" href="clock-folio.html">Open Project Folio</a></div>
       </div>
-      <figure class="hero-showcase hero-image-contain">
+      <figure class="hero-showcase">
         <img class="hero-chair clock-hero-product" src="assets/clock-hero-illustrative-v3.png" alt="Timber clock similar in form to the student Clock project, shown in a school workshop setting">
         <figcaption class="hero-image-note">Illustrative Clock reference image · use the supplied project plans for technical and dimensional authority</figcaption>
       </figure>

--- a/shared/hub-navigation.js
+++ b/shared/hub-navigation.js
@@ -1,45 +1,60 @@
 (function () {
   "use strict";
 
-  const HUB_URL = "https://stevencowell.github.io/Main-Page/";
-  const BUSY_WORK_URL = "https://stevencowell.github.io/busy-worksheets/?library=timber";
-  const script = document.currentScript;
-  const stylesheetUrl = script ? new URL("sister-site.css", script.src).href : "";
+  if (document.querySelector(".course-family-nav")) return;
 
-  if (stylesheetUrl && !document.querySelector('link[data-sister-site-styles]')) {
+  const script = document.currentScript;
+  const root = new URL("../", script && script.src ? script.src : location.href);
+  const stylesheetUrl = new URL("course-family-navigation.css?v=20260814", root).href;
+
+  if (!document.querySelector("link[data-course-family-nav-styles]")) {
     const stylesheet = document.createElement("link");
     stylesheet.rel = "stylesheet";
     stylesheet.href = stylesheetUrl;
-    stylesheet.dataset.sisterSiteStyles = "";
+    stylesheet.dataset.courseFamilyNavStyles = "";
     document.head.append(stylesheet);
   }
 
-  if (document.querySelector(".hub-return-bar")) return;
+  const path = location.pathname.toLowerCase();
+  const rootPath = root.pathname.replace(/\/$/, "").toLowerCase();
+  const isHome = path === `${rootPath}/` || path === `${rootPath}/index.html`;
 
-  const heading = document.querySelector("h1");
-  const courseLabel = heading && heading.textContent.trim() ? heading.textContent.trim() : document.title;
-  const bar = document.createElement("nav");
-  bar.className = "hub-return-bar screen-only";
-  bar.setAttribute("aria-label", "Industrial Arts Learning Hub navigation");
+  const nav = document.createElement("nav");
+  nav.className = "course-family-nav screen-only";
+  nav.setAttribute("aria-label", "Clock course navigation");
 
   const inner = document.createElement("div");
-  inner.className = "hub-return-inner";
+  inner.className = "course-family-nav__inner";
 
-  const link = document.createElement("a");
-  link.className = "hub-return-link";
-  link.href = HUB_URL;
-  link.innerHTML = '<span aria-hidden="true">←</span><span>Main menu · Industrial Arts Learning Hub</span>';
+  const brand = document.createElement("a");
+  brand.className = "course-family-nav__brand";
+  brand.href = new URL("index.html", root).href;
+  brand.innerHTML = '<span class="course-family-nav__mark" aria-hidden="true">CL</span><span>Clock</span>';
 
-  const label = document.createElement("span");
-  label.className = "hub-course-label";
-  label.textContent = courseLabel;
+  const links = document.createElement("div");
+  links.className = "course-family-nav__links";
 
-  const busyWork = document.createElement("a");
-  busyWork.className = "hub-return-link";
-  busyWork.href = BUSY_WORK_URL;
-  busyWork.textContent = "Busy Work";
+  const items = [
+    ["Course", "index.html", isHome],
+    ["Modules", "index.html#course-map-title", /\/weeks\d+-\d+\//.test(path)],
+    ["Video learning", "youtube-library/", path.includes("/youtube-library/")],
+    ["Busy Work", "https://stevencowell.github.io/busy-worksheets/?library=timber", false, true],
+    ["My folio", "clock-folio.html", path.endsWith("/clock-folio.html")],
+    ["Project plans", "Drawing%201%20(1).pdf", false],
+    ["Teacher resources", "teacher-resources.html", path.endsWith("/teacher-resources.html")],
+    ["Main Menu", "https://stevencowell.github.io/Main-Page/", false, true]
+  ];
 
-  inner.append(link, busyWork, label);
-  bar.append(inner);
-  document.body.prepend(bar);
+  items.forEach(([label, href, current, external]) => {
+    const link = document.createElement("a");
+    link.textContent = label;
+    link.href = external ? href : new URL(href, root).href;
+    if (current) link.setAttribute("aria-current", "page");
+    links.append(link);
+  });
+
+  inner.append(brand, links);
+  nav.append(inner);
+  document.body.prepend(nav);
+  document.documentElement.classList.add("has-course-family-nav");
 })();

--- a/teacher-resources.html
+++ b/teacher-resources.html
@@ -1,0 +1,59 @@
+<!doctype html>
+<html lang="en-AU">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="Teacher resources and delivery controls for the Year 9 Timber Clock course.">
+  <title>Teacher Resources | Clock</title>
+  <link rel="stylesheet" href="styles/course.css">
+  <link rel="stylesheet" href="styles/clock-overrides.css">
+  <link rel="stylesheet" href="shared/sister-site.css">
+  <link rel="stylesheet" href="course-family-navigation.css?v=20260814" data-course-family-nav-styles>
+  <link rel="stylesheet" href="course-family-hero.css">
+  <script src="shared/hub-navigation.js?v=20260814" defer></script>
+</head>
+<body>
+  <a class="skip-link" href="#main-content">Skip to teacher resources</a>
+  <header class="hero landing-hero sister-hero course-family-hero" style="--hero-start:#173b59;--hero-end:#517b91;--hero-accent:#e9b662">
+    <div class="hero-inner course-family-hero-inner">
+      <div class="hero-copy">
+        <p class="eyebrow">Year 9 Industrial Technology – Timber</p>
+        <h1>Teacher Resources</h1>
+        <p class="hero-subtitle">Approved project documents, assessment information and local delivery controls for the Clock course.</p>
+        <div class="hero-actions">
+          <a class="button-link" href="index.html">Course Home</a>
+          <a class="button-link secondary" href="assessment-notification.html">Assessment Notification</a>
+        </div>
+      </div>
+      <figure class="hero-showcase hero-image-contain">
+        <img src="assets/clock-hero-illustrative-v3.png" alt="Illustrative timber Clock project reference">
+        <figcaption class="hero-image-note">Illustrative reference only · the supplied drawing and teacher direction remain authoritative</figcaption>
+      </figure>
+    </div>
+  </header>
+  <main id="main-content" class="landing-main">
+    <section class="card">
+      <p class="section-kicker">Approved project resources</p>
+      <h2>Use the supplied drawing and current formal notification</h2>
+      <p>The working drawing controls project dimensions and notes. It states <strong>DO NOT SCALE DRAWING</strong>. Confirm current dates, issue conditions and any local adjustments before delivery.</p>
+      <div class="resource-actions">
+        <a class="button-link" href="Drawing%201%20(1).pdf" target="_blank" rel="noopener">Open Supplied Drawing</a>
+        <a class="button-link secondary" href="Clock%20Assessment%20Criteria.pdf" target="_blank" rel="noopener">Open Assessment Criteria</a>
+      </div>
+    </section>
+    <section class="card">
+      <p class="section-kicker">Delivery boundary</p>
+      <h2>Teacher and workshop controls remain authoritative</h2>
+      <p>Dimensions, stock sizes, tolerances, machine settings, setup, practical permissions, assessment conditions and submission routes remain teacher controlled. Students must use the school SOP and SWMS applicable to the actual workshop equipment.</p>
+      <p>Browser evidence is a working copy. Nothing is submitted automatically.</p>
+    </section>
+    <section class="card">
+      <p class="section-kicker">Staff change request</p>
+      <h2>Suggest a change</h2>
+      <p>Report the affected page, the proposed correction and the approved source supporting it.</p>
+      <a class="button-link" href="https://github.com/stevencowell/Yr-9-Clock/issues/new?title=Clock%20course%20change%20request&amp;body=Page%20or%20module%3A%0A%0ASuggested%20change%3A%0A%0AApproved%20source%3A%0A" target="_blank" rel="noopener">Suggest a Change</a>
+    </section>
+  </main>
+  <footer><p>Clock Teacher Resources</p><p>Wagga Wagga High School | Industrial Technology – Timber</p></footer>
+</body>
+</html>


### PR DESCRIPTION
## What changed
- replaced the two-link return bar with the full shared Timber course navigation
- added Course, Modules, Video learning, Busy Work, My folio, Project plans, Teacher resources and Main Menu
- added a staff-only Teacher Resources page containing approved project links, delivery boundaries and the change-request action
- reduced the front-page hero to the standard two student actions

## Why
The student-facing course needed the same predictable navigation and teacher-resource separation used across the Timber site family.

## Checks
- commit-specific RawGitHack preview opens
- navigation renders without horizontal page overflow on mobile
- Teacher resources is reachable from the header
- “Suggest a Change” appears only on the teacher page
- no browser console errors observed

Draft only; nothing has been merged or pushed live.

## Latest visual refinements

- Changed the Clock hero image from contained to cover framing and centred the crop on the clock so it fills more of the card.
- Rechecked the front page for clipping and horizontal overflow.

## Follow-up hero framing

- Removed the Clock image’s legacy inner border, rounded corners, shadow and fixed aspect ratio so only the shared hero card remains.
- Centred and resized the crop so the full Clock, including its base, sits cleanly within the card.